### PR TITLE
ci: add PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+# This workflow will build and publish the Python package to PyPI when a release is created.
+# It uses PyPI's trusted publishing feature for secure, passwordless deployment.
+#
+# For more information, see:
+# - https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# - https://github.com/pypi/gh-action-pypi-publish
+
+name: Publish Python Package to PyPI
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package
+          path: dist/
+          retention-days: 1
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/robofactor
+    permissions:
+      id-token: write # This is required for trusted publishing
+    steps:
+      - name: Download a single artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package
+          path: dist/
+
+      - name: Publish package to PyPI
+        uses: pypi/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build and publish process for a Python package to PyPI. The workflow leverages PyPI's trusted publishing feature for secure and passwordless deployment.

### New GitHub Actions Workflow:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R61): Added a workflow named "Publish Python Package to PyPI" that builds the package using `uv`, uploads it as an artifact, and publishes it to PyPI using PyPI's trusted publishing feature.