### PR TITLE
docs: update README to reflect proper publish ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The robot who refactors: /[^_^]\
 
 [![PyPI version](https://img.shields.io/pypi/v/robofactor)](https://pypi.org/project/robofactor)
-[![Build Status](https://github.com/ethan-wickstrom/robofactor/actions/workflows/ci.yml/badge.svg)](https://github.com/ethan-wickstrom/robofactor/actions)
+[![Build Status](https://github.com/ethan-wickstrom/robofactor/actions/workflows/publish.yml/badge.svg)](https://github.com/ethan-wickstrom/robofactor/actions)
 [![License](https://img.shields.io/pypi/l/robofactor)](https://github.com/ethan-wickstrom/robofactor)
 [![Python versions](https://img.shields.io/pypi/pyversions/robofactor)](https://pypi.org/project/robofactor)
 


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect changes in the CI badge link.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6): Updated the CI badge to point to the `publish.yml` workflow instead of `ci.yml`.