### PR TITLE
fix(ci): validate extracted version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,8 +37,19 @@ jobs:
         id: extract_version
         uses: damienaicheh/extract-version-from-tag-action@v1.3.0
 
+      - name: Validate extracted version
+        run: |
+          set -e
+          if [ -z "${{ steps.extract_version.outputs.version }}" ]; then
+            echo "Error: Extracted version is empty."
+            exit 1
+          fi
+          echo "Extracted version: ${{ steps.extract_version.outputs.version }}"
+
       - name: Update pyproject.toml version
         run: |
+          set -e
+          # The extract-version-from-tag-action already strips the 'v' prefix.
           VERSION="${{ steps.extract_version.outputs.version }}"
           echo "Updating pyproject.toml to version ${VERSION}"
           sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml


### PR DESCRIPTION
This pull request fixes a bug in the PyPI publishing workflow where an empty version string could cause the build to fail.

A validation step has been added to ensure that the version extracted from the Git tag is not empty before attempting to update . This makes the release process more resilient.