### PR TITLE
fix(ci): validate extracted version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,9 +37,19 @@ jobs:
         id: extract_version
         uses: damienaicheh/extract-version-from-tag-action@v1.3.0
 
+      - name: Validate extracted version
+        run: |
+          set -e
+          if [ -z "${{ steps.extract_version.outputs.version }}" ]; then
+            echo "Error: Extracted version is empty."
+            exit 1
+          fi
+
       - name: Update pyproject.toml version
         run: |
-          VERSION="${{ steps.extract_version.outputs.version }}"
+          set -e
+          # Strip 'v' prefix for PEP 440 compliance
+          VERSION=$(echo "${{ steps.extract_version.outputs.version }}" | sed 's/^v//')
           echo "Updating pyproject.toml to version ${VERSION}"
           sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
           echo "Verifying pyproject.toml:"


### PR DESCRIPTION
This pull request fixes a bug in the PyPI publishing workflow where an empty or invalid version string could be written to , causing the build to fail.

The following changes have been made:
- Added a step to validate that the version extracted from the Git tag is not empty.
- Added  to the version update script to ensure it fails fast.
- Ensured the leading 'v' is stripped from the version tag.

These changes will prevent the build from failing due to an invalid version and make the release process more reliable.