### PR TITLE
fix(ci): correct version extraction in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,30 +26,21 @@ jobs:
           # Fetch all history for all branches and tags for version extraction
           fetch-depth: 0
 
-      - name: Validate version tag
-        run: |
-          if [[ ! "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: Tag must be in format v*.*.* (e.g., v1.2.3)"
-            exit 1
-          fi
-
-      - name: Extract version from tag
+      - name: Validate and Extract Version
         id: extract_version
-        uses: damienaicheh/extract-version-from-tag-action@v1.3.0
-
-      - name: Validate extracted version
         run: |
-          set -e
-          if [ -z "${{ steps.extract_version.outputs.version }}" ]; then
-            echo "Error: Extracted version is empty."
+          if [[ "${{ github.ref }}" =~ ^refs/tags/v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "version=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          else
+            echo "Error: Tag is not in a valid semantic versioning format (e.g., v1.2.3)"
             exit 1
           fi
+        shell: bash
 
       - name: Update pyproject.toml version
         run: |
           set -e
-          # Strip 'v' prefix for PEP 440 compliance
-          VERSION=$(echo "${{ steps.extract_version.outputs.version }}" | sed 's/^v//')
+          VERSION="${{ steps.extract_version.outputs.version }}"
           echo "Updating pyproject.toml to version ${VERSION}"
           sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
           echo "Verifying pyproject.toml:"


### PR DESCRIPTION
This pull request fixes a bug in the PyPI publishing workflow where the version was not being correctly extracted from the Git tag due to a deprecated action.

This has been resolved by replacing the external action with a self-contained shell command that extracts the version using regex and sets it as a job output. This removes the dependency on the outdated action and makes the workflow more reliable.